### PR TITLE
HOPPR data support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,19 @@
 =============
- dicom2nifti
+Hyperfine dicom to nifti converter based on the following package
+=============
+---------------
+ Hyperfine specific quickstart examples
+---------------
+
+
+.. code-block:: bash
+
+   python scripts/quickstart_hyperfine.py
+
+
+
+=============
+ dicom2nifti original documentation starting
 =============
 
 Python library for converting dicom files to nifti

--- a/dicom2nifti/common.py
+++ b/dicom2nifti/common.py
@@ -92,6 +92,16 @@ def is_ge(dicom_input):
     return True
 
 
+def is_hyperfine(dicom_input):
+    # Check if the dicom (most likely a multiframe one) is produced
+    # by Hyperfine Swoop.
+    header = dicom_input[0]
+    if 'Hyperfine' in header.Manufacturer:
+        raise NotImplementedError(
+            'Do not support Hyperfine DCMs, use dicom2nixx instead.')
+    return False
+
+
 def is_philips(dicom_input):
     """
     Use this function to detect if a dicom series is a philips dataset
@@ -162,6 +172,9 @@ def is_valid_imaging_dicom(dicom_header):
     """
     # if it is philips and multiframe dicom then we assume it is ok
     try:
+        if is_hyperfine([dicom_header]):
+            return False
+
         if is_philips([dicom_header]):
             if is_multiframe_dicom([dicom_header]):
                 return True

--- a/dicom2nifti/convert_dicom.py
+++ b/dicom2nifti/convert_dicom.py
@@ -40,6 +40,7 @@ class Vendor(object):
     GE = 2
     PHILIPS = 3
     HITACHI = 4
+    HYPERFINE = 5
 
 
 # pylint: enable=w0232, r0903, C0103
@@ -113,9 +114,10 @@ def dicom_array_to_nifti(dicom_list, output_file, reorient_nifti=True):
         raise ConversionValidationError('NON_IMAGING_DICOM_FILES')
 
     vendor = _get_vendor(dicom_list)
-
     if vendor == Vendor.GENERIC:
         results = convert_generic.dicom_to_nifti(dicom_list, output_file)
+    elif vendor == Vendor.HYPERFINE:
+        results = convert_philips.dicom_to_nifti(dicom_list, output_file)
     elif vendor == Vendor.SIEMENS:
         results = convert_siemens.dicom_to_nifti(dicom_list, output_file)
     elif vendor == Vendor.GE:
@@ -151,7 +153,8 @@ def are_imaging_dicoms(dicom_input):
     if common.is_philips(dicom_input):
         if common.is_multiframe_dicom(dicom_input):
             return True
-
+    if common.is_hyperfine(dicom_input):
+        return True
     # for all others if there is image position patient we assume it is ok
     header = dicom_input[0]
     return Tag(0x0020, 0x0037) in header
@@ -163,6 +166,9 @@ def _get_vendor(dicom_input):
     Possibilities are fMRI, DTI, Anatomical (if no clear type is found anatomical is used)
     """
     # check if it is siemens
+    if common.is_hyperfine(dicom_input):
+        logger.info('Found manufacturer: HYPERFINE')
+        return Vendor.HYPERFINE
     if common.is_siemens(dicom_input):
         logger.info('Found manufacturer: SIEMENS')
         return Vendor.SIEMENS

--- a/dicom2nifti/convert_dicom.py
+++ b/dicom2nifti/convert_dicom.py
@@ -116,8 +116,6 @@ def dicom_array_to_nifti(dicom_list, output_file, reorient_nifti=True):
     vendor = _get_vendor(dicom_list)
     if vendor == Vendor.GENERIC:
         results = convert_generic.dicom_to_nifti(dicom_list, output_file)
-    elif vendor == Vendor.HYPERFINE:
-        results = convert_philips.dicom_to_nifti(dicom_list, output_file)
     elif vendor == Vendor.SIEMENS:
         results = convert_siemens.dicom_to_nifti(dicom_list, output_file)
     elif vendor == Vendor.GE:

--- a/dicom2nifti/convert_dir.py
+++ b/dicom2nifti/convert_dir.py
@@ -19,11 +19,25 @@ import logging
 import dicom2nifti.common as common
 import dicom2nifti.convert_dicom as convert_dicom
 import dicom2nifti.settings
+from experimental import utils
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[
+        logging.FileHandler("dicom2nifti.log"),
+        logging.StreamHandler()
+    ]
+)
 
 logger = logging.getLogger(__name__)
 
 
-def convert_directory(dicom_directory, output_folder, compression=True, reorient=True):
+def convert_directory(
+        dicom_directory,
+        output_folder,
+        compression=True,
+        reorient=True):
     """
     This function will order all dicom files by series and order them one by one
 
@@ -43,52 +57,101 @@ def convert_directory(dicom_directory, output_folder, compression=True, reorient
                     # read the dicom as fast as possible
                     # (max length for SeriesInstanceUID is 64 so defer_size 100 should be ok)
 
-                    dicom_headers = compressed_dicom.read_file(file_path,
-                                                               defer_size="1 KB",
-                                                               stop_before_pixels=False,
-                                                               force=dicom2nifti.settings.pydicom_read_force)
+                    dicom_headers = compressed_dicom.read_file(
+                        file_path,
+                        defer_size="1 KB",
+                        stop_before_pixels=False,
+                        force=dicom2nifti.settings.pydicom_read_force)
                     if not _is_valid_imaging_dicom(dicom_headers):
                         logger.info("Skipping: %s" % file_path)
                         continue
                     logger.info("Organizing: %s" % file_path)
                     if dicom_headers.SeriesInstanceUID not in dicom_series:
                         dicom_series[dicom_headers.SeriesInstanceUID] = []
-                    dicom_series[dicom_headers.SeriesInstanceUID].append(dicom_headers)
-            except:  # Explicitly capturing all errors here to be able to continue processing all the rest
+                    dicom_series[dicom_headers.SeriesInstanceUID].append(
+                        {'dicom': dicom_headers, 'dicom_file_path': file_path})
+            except BaseException:  # Explicitly capturing all errors here to be able to continue processing all the rest
                 logger.warning("Unable to read: %s" % file_path)
                 traceback.print_exc()
 
+    # further divide one series into multiple sub-series by sequence_name
+    series_new = {}
+    for series_id, entries in dicom_series.items():
+        dicoms = [entry['dicom'] for entry in entries]
+        if 'SequenceName' in dicoms[0]:
+            sequence_names = list(
+                set([dicom.SequenceName for dicom in dicoms]))
+            if len(sequence_names) == 1:
+                series_new[series_id] = entries
+            else:
+                for ii, sequence_name in enumerate(sequence_names):
+                    series_new['%s.%d' % (series_id, ii)] = [entries[ii] for ii, dicom in enumerate(
+                        dicoms) if dicom.SequenceName == sequence_name]
+        else:
+            series_new[series_id] = entries
+    dicom_series = series_new
     # start converting one by one
-    for series_id, dicom_input in dicom_series.items():
+    for _, entries in dicom_series.items():
+        dicom_input = [entry['dicom'] for entry in entries]
+        dicom_file_paths = [entry['dicom_file_path'] for entry in entries]
         base_filename = ""
         # noinspection PyBroadException
         try:
             # construct the filename for the nifti
             base_filename = ""
             if 'SeriesNumber' in dicom_input[0]:
-                base_filename = _remove_accents('%s' % dicom_input[0].SeriesNumber)
+                base_filename = _remove_accents_(
+                    'series_number@%s' %
+                    dicom_input[0].SeriesNumber)
                 if 'SeriesDescription' in dicom_input[0]:
-                    base_filename = _remove_accents('%s_%s' % (base_filename,
-                                                               dicom_input[0].SeriesDescription))
-                elif 'SequenceName' in dicom_input[0]:
-                    base_filename = _remove_accents('%s_%s' % (base_filename,
-                                                               dicom_input[0].SequenceName))
-                elif 'ProtocolName' in dicom_input[0]:
-                    base_filename = _remove_accents('%s_%s' % (base_filename,
-                                                               dicom_input[0].ProtocolName))
+                    base_filename = _remove_accents_(
+                        '%s@series_description@%s' %
+                        (base_filename, dicom_input[0].SeriesDescription))
+                if 'SequenceName' in dicom_input[0]:
+                    base_filename = _remove_accents_(
+                        '%s@sequence_name@%s' %
+                        (base_filename, dicom_input[0].SequenceName))
+                if 'ProtocolName' in dicom_input[0]:
+                    base_filename = _remove_accents_(
+                        '%s@protocol_name@%s' %
+                        (base_filename, dicom_input[0].ProtocolName))
             else:
-                base_filename = _remove_accents(dicom_input[0].SeriesInstanceUID)
+                base_filename = _remove_accents_(
+                    dicom_input[0].SeriesInstanceUID)
             logger.info('--------------------------------------------')
             logger.info('Start converting %s' % base_filename)
+
             if compression:
-                nifti_file = os.path.join(output_folder, base_filename + '.nii.gz')
+                nifti_file = os.path.join(
+                    output_folder, base_filename + '.nii.gz')
             else:
-                nifti_file = os.path.join(output_folder, base_filename + '.nii')
-            convert_dicom.dicom_array_to_nifti(dicom_input, nifti_file, reorient)
+                nifti_file = os.path.join(
+                    output_folder, base_filename + '.nii')
+            convert_dicom.dicom_array_to_nifti(
+                dicom_input, nifti_file, reorient)
+
+            # record dicom tags in json
+            json_out = {'dicoms': [], 'nifti': nifti_file}
+            for dicom, dicom_file_path in zip(dicom_input, dicom_file_paths):
+                dicom = utils.convert_dicom_value(dicom)
+                dicom.pop('PixelData')
+                dicom.update({'dicom_file_path': dicom_file_path})
+                json_out['dicoms'].append(dicom)
+            utils.dump_json(
+                json_out,
+                os.path.join(
+                    output_folder,
+                    base_filename +
+                    '.json'))
+
             gc.collect()
-        except:  # Explicitly capturing app exceptions here to be able to continue processing
+        except Exception as exception:  # Explicitly capturing app exceptions here to be able to continue processing
             logger.info("Unable to convert: %s" % base_filename)
-            traceback.print_exc()
+            if str(exception) not in [
+                'TOO_FEW_SLICES/LOCALIZER',
+                "MISSING_DICOM_FILES",
+                    "SLICE_INCREMENT_INCONSISTENT"]:
+                traceback.print_exc()
 
 
 def _is_valid_imaging_dicom(dicom_header):
@@ -97,6 +160,9 @@ def _is_valid_imaging_dicom(dicom_header):
     """
     # if it is philips and multiframe dicom then we assume it is ok
     try:
+        if common.is_hyperfine([dicom_header]):
+            return True
+
         if common.is_philips([dicom_header]):
             if common.is_multiframe_dicom([dicom_header]):
                 return True
@@ -107,10 +173,12 @@ def _is_valid_imaging_dicom(dicom_header):
         if "InstanceNumber" not in dicom_header:
             return False
 
-        if "ImageOrientationPatient" not in dicom_header or len(dicom_header.ImageOrientationPatient) < 6:
+        if "ImageOrientationPatient" not in dicom_header or len(
+                dicom_header.ImageOrientationPatient) < 6:
             return False
 
-        if "ImagePositionPatient" not in dicom_header or len(dicom_header.ImagePositionPatient) < 3:
+        if "ImagePositionPatient" not in dicom_header or len(
+                dicom_header.ImagePositionPatient) < 3:
             return False
 
         # for all others if there is image position patient we assume it is ok
@@ -130,13 +198,16 @@ def _remove_accents(unicode_filename):
     # noinspection PyBroadException
     try:
         unicode_filename = unicode_filename.replace(" ", "_")
-        cleaned_filename = unicodedata.normalize('NFKD', unicode_filename).encode('ASCII', 'ignore').decode('ASCII')
+        cleaned_filename = unicodedata.normalize(
+            'NFKD', unicode_filename).encode(
+            'ASCII', 'ignore').decode('ASCII')
 
-        cleaned_filename = re.sub(r'[^\w\s-]', '', cleaned_filename.strip().lower())
+        cleaned_filename = re.sub(
+            r'[^\w\s-]', '', cleaned_filename.strip().lower())
         cleaned_filename = re.sub(r'[-\s]+', '-', cleaned_filename)
 
         return cleaned_filename
-    except:
+    except BaseException:
         traceback.print_exc()
         return unicode_filename
 
@@ -146,8 +217,12 @@ def _remove_accents_(unicode_filename):
     Function that will try to remove accents from a unicode string to be used in a filename.
     input filename should be either an ascii or unicode string
     """
-    valid_characters = bytes(b'-_.() 1234567890abcdefghijklmnopqrstuvwxyz')
-    cleaned_filename = unicodedata.normalize('NFKD', unicode_filename).encode('ASCII', 'ignore')
+    unicode_filename = unicode_filename.replace(" ", "_")
+    unicode_filename = unicode_filename.strip().lower()
+    valid_characters = bytes(b'@-_.()1234567890abcdefghijklmnopqrstuvwxyz')
+    cleaned_filename = unicodedata.normalize(
+        'NFKD', unicode_filename).encode(
+        'ASCII', 'ignore')
 
     new_filename = ""
 

--- a/dicom2nifti/convert_dir.py
+++ b/dicom2nifti/convert_dir.py
@@ -19,7 +19,7 @@ import logging
 import dicom2nifti.common as common
 import dicom2nifti.convert_dicom as convert_dicom
 import dicom2nifti.settings
-from experimental import utils
+
 
 logging.basicConfig(
     level=logging.INFO,
@@ -133,11 +133,11 @@ def convert_directory(
             # record dicom tags in json
             json_out = {'dicoms': [], 'nifti': nifti_file}
             for dicom, dicom_file_path in zip(dicom_input, dicom_file_paths):
-                dicom = utils.convert_dicom_value(dicom)
+                dicom = common.convert_dicom_value(dicom)
                 dicom.pop('PixelData')
                 dicom.update({'dicom_file_path': dicom_file_path})
                 json_out['dicoms'].append(dicom)
-            utils.dump_json(
+            common.dump_json(
                 json_out,
                 os.path.join(
                     output_folder,
@@ -161,7 +161,7 @@ def _is_valid_imaging_dicom(dicom_header):
     # if it is philips and multiframe dicom then we assume it is ok
     try:
         if common.is_hyperfine([dicom_header]):
-            return True
+            return False
 
         if common.is_philips([dicom_header]):
             if common.is_multiframe_dicom([dicom_header]):

--- a/dicom2nifti/convert_philips.py
+++ b/dicom2nifti/convert_philips.py
@@ -22,6 +22,7 @@ from dicom2nifti.exceptions import ConversionError, ConversionValidationError
 pydicom_config.enforce_valid_values = False
 logger = logging.getLogger(__name__)
 
+
 def dicom_to_nifti(dicom_input, output_file=None):
     """
     This is the main dicom to nifti conversion fuction for philips images.
@@ -33,7 +34,7 @@ def dicom_to_nifti(dicom_input, output_file=None):
     :param dicom_input: directory with dicom files for 1 scan
     """
 
-    assert common.is_philips(dicom_input) or common.is_hyperfine(dicom_input)
+    assert common.is_philips(dicom_input)
 
     # remove duplicate slices based on position and data
     dicom_input = convert_generic.remove_duplicate_slices(dicom_input)
@@ -49,8 +50,6 @@ def dicom_to_nifti(dicom_input, output_file=None):
         raise ConversionValidationError('TOO_FEW_SLICES/LOCALIZER')
 
     if common.is_multiframe_dicom(dicom_input):
-        if common.is_hyperfine(dicom_input):
-            raise NotImplementedError()
         _assert_explicit_vr(dicom_input)
         logger.info('Found multiframe dicom')
         if _is_multiframe_4d(dicom_input):
@@ -222,7 +221,7 @@ def _is_float(value):
         return False
 
 
-def _multiframe_to_nifti(dicom_input, output_file, hyperfine=False):
+def _multiframe_to_nifti(dicom_input, output_file):
     """
     This function will convert philips 4D or anatomical multiframe series to a nifti
     """
@@ -247,9 +246,8 @@ def _multiframe_to_nifti(dicom_input, output_file, hyperfine=False):
     nii_image = nibabel.Nifti1Image(full_block, affine)
     timing_parameters = multiframe_dicom.SharedFunctionalGroupsSequence[0].MRTimingAndRelatedParametersSequence[0]
     first_frame = multiframe_dicom[Tag(0x5200, 0x9230)][0]
-    if not hyperfine:
-        common.set_tr_te(nii_image, float(timing_parameters.RepetitionTime),
-                         float(first_frame[0x2005, 0x140f][0].EchoTime))
+    common.set_tr_te(nii_image, float(timing_parameters.RepetitionTime),
+                     float(first_frame[0x2005, 0x140f][0].EchoTime))
 
     # Save to disk
     if output_file is not None:

--- a/scripts/quickstart_hyperfine.py
+++ b/scripts/quickstart_hyperfine.py
@@ -36,6 +36,6 @@ def main(mode):
 
 
 if __name__ == '__main__':
-    #main('yale_lowfield')
-    #main('yale_highfield')
+    main('yale_lowfield')
+    main('yale_highfield')
     main('hoppr_highfield')

--- a/scripts/quickstart_hyperfine.py
+++ b/scripts/quickstart_hyperfine.py
@@ -1,0 +1,41 @@
+import os
+import dicom2nifti
+
+# example data for demo purpose
+DATA_DIR = '/data/tmp/lyao/data/dicom_to_nifti_quick_start'
+
+YALE_LOWFIELD_DICOMS = os.path.join(DATA_DIR, 'yale_lowfield/DICOMDIR')
+YALE_LOWFIELD_NIFTIS = os.path.join(DATA_DIR, 'yale_lowfield/NIFTIS')
+
+YALE_HIGHFIELD_DICOMS = os.path.join(DATA_DIR, 'yale_highfield/DICOMDIR')
+YALE_HIGHFIELD_NIFTIS = os.path.join(DATA_DIR, 'yale_highfield/NIFTIS')
+
+HOPPR_HIGHFIELD_DICOMS = os.path.join(DATA_DIR, 'hoppr_highfield/DICOMDIR')
+HOPPR_HIGHFIELD_NIFTIS = os.path.join(DATA_DIR, 'hoppr_highfield/NIFTIS')
+
+
+def main(mode):
+    if mode == 'yale_lowfield':
+        os.makedirs(YALE_LOWFIELD_NIFTIS, exist_ok=True)
+        cmd = f'dcm2niix -ba n -f pid@%i@@series@%s@@desp@%d -o {YALE_LOWFIELD_NIFTIS} {YALE_LOWFIELD_DICOMS}'
+        os.system(cmd)
+    elif mode == 'yale_highfield':
+        dicom2nifti.settings.validate_orthogonal = False
+        dicom2nifti.settings.validate_slicecount = True
+        dicom2nifti.settings.validate_orientation = True
+        os.makedirs(YALE_HIGHFIELD_NIFTIS, exist_ok = True)
+        dicom2nifti.convert_dir.convert_directory(
+            YALE_HIGHFIELD_DICOMS, YALE_HIGHFIELD_NIFTIS, compression=False)
+    elif mode == 'hoppr_highfield':
+        dicom2nifti.settings.validate_slice_increment = True
+        os.makedirs(HOPPR_HIGHFIELD_NIFTIS, exist_ok=True)
+        dicom2nifti.convert_dir.convert_directory(
+            HOPPR_HIGHFIELD_DICOMS, HOPPR_HIGHFIELD_NIFTIS, compression=False)
+    else:
+        raise NotImplementedError()
+
+
+if __name__ == '__main__':
+    #main('yale_lowfield')
+    #main('yale_highfield')
+    main('hoppr_highfield')


### PR DESCRIPTION
By default, it won't separate series by `SequenceName`, this is a hack to make it work with HOPPR. The basic idea is to detect within the same `SeriesInstanceUID` multiple `SequenceName` values. Then  manually separate one series into sub-series by overwriting their `SeriesInstanceUID`s. 

I also tried a few things to make it work with Hyperfine data, but unfortunately this is quite hard as our dicom is in a weird format that is not compatible with any existing manufacturer's standard. So my recommendation here is to still stick with `dicom2nixx` which we already use.  